### PR TITLE
fix chmod install fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-hyperfused
 test
 dist

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ test: $(SRC_C) $(SRC_H) tests/*.c
 	./$@
 
 clean:
-	rm -f test hyperfused
+	rm -fr test hyperfused
 
 .PHONY: test clean install uninstall

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "make test",
-    "install": "make"
+    "install": "make clean && make",
+    "prepublish": "make clean && touch hyperfused"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The problem is that npm is trying to chmod the `hyperfused` file which is supplied to the `bin` field in package.json. But it doesn't exist yet so we get an `ENOENT`. Easy solution (that will remain cross platform) is to supply an empty dummy `hyperfused` file, on install run `make clean` to clear it then `make` to overwrite. The link will still be setup with the correct execution perms, and still point to the same path, which will now be our built `hyperfused` file. A prepublish script ensures that the dummy hyperfused is published to npm rather than the binary.

``` sh
$ npm i -g hyperfused
npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/bin/iojs" "/Users/davidclements/npm-global/bin/npm" "i" "-g" "hyperfused"
npm ERR! node v5.1.1
npm ERR! npm  v3.5.0
npm ERR! path /Users/davidclements/npm-global/lib/node_modules/hyperfused/hyperfused
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod

npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/davidclements/npm-global/lib/node_modules/hyperfused/hyperfused'
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/davidclements/npm-global/lib/node_modules/hyperfused/hyperfused'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/davidclements/z/nearForm/tfs/npm-debug.log
```
